### PR TITLE
Fixed XSS vulnerability on rating action

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed XSS vulnerability on rating action
+  [keul, cekk]
 
 
 1.1 (2013-09-20)

--- a/contentratings/browser/basic.py
+++ b/contentratings/browser/basic.py
@@ -7,6 +7,7 @@ from contentratings.browser.interfaces import IRatingView
 from contentratings.interfaces import _
 from zope.schema.interfaces import IVocabularyTokenized
 from ZPublisher.BaseRequest import DefaultPublishTraverse
+from zExceptions import BadRequest
 
 try:
     from Products.statusmessages.interfaces import IStatusMessage
@@ -60,7 +61,13 @@ class BasicEditorialRatingView(object):
     def rate(self, value, redirect=True):
         """Rate the content.  Enforce vocabulary values.
         """
-        assert int(value) in self.vocabulary
+        try:
+            value = int(value)
+            if value not in self.vocabulary:
+                raise ValueError()
+        except ValueError:
+            raise BadRequest("Invalid rating value")
+
         msg = _(u'The rating has been changed')
 
         self.context.rating = value
@@ -126,7 +133,13 @@ class BasicUserRatingView(BasicEditorialRatingView):
     def rate(self, value, redirect=True):
         """Rate the content.  Enforce vocabulary values.
         """
-        assert int(value) in self.vocabulary
+        try:
+            value = int(value)
+            if value not in self.vocabulary:
+                raise ValueError()
+        except ValueError:
+            raise BadRequest("Invalid rating value")
+
         context = self.context
         userid = context.userid
         msg = _(u'You have changed your rating')

--- a/contentratings/browser/views.txt
+++ b/contentratings/browser/views.txt
@@ -116,7 +116,7 @@ The view ensures that input values are valid in the vocabulary::
     >>> view.rate(3) # doctest: +ELLIPSIS
     Traceback (most recent call last):
     ...
-    AssertionError
+    BadRequest: Invalid rating value
 
 And the manager ensures that the category conditions are checked::
 


### PR DESCRIPTION
Security report from our customer reported a XSS vulnerability in the rating product.

Very simple to be reproduced: just add `.../++UserRating++/rate?value=<script>alert(%22Gotcha%22)</script>` after the rating URL.
